### PR TITLE
release v1.1

### DIFF
--- a/src/PACKAGE
+++ b/src/PACKAGE
@@ -1,7 +1,7 @@
 package: Slingshot Auto Loader
 author: Slingshot Systems Inc.
 organization: Slingshot Systems Inc.
-version: 1.1.0
+version: 1.1
 requires: ""
 rv: 4.0.7
 openrv: 1.0.0


### PR DESCRIPTION
RV requires version numbers to only be x.x so let's do 1.1 instead of 1.1.0