### PR TITLE
feat: use OCIO for CDL/LUTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When a plugin in loaded and installed in RV, you can directly edit or replace py
 Testing is difficult outside of the RV environment, but you can run the few tests we have using `pytest`:
 
 ```shell
-poetry run pytest ./tests/
+uv run pytest ./tests/
 ```
 
 ---

--- a/src/PACKAGE
+++ b/src/PACKAGE
@@ -21,9 +21,9 @@ files:
 description: |
   <h2>Slingshot Auto Loader</h2>
   <p>This is a package that automatically loads plates, v000s, luts, and/or CDLs from designated relative paths.</p>
-  <br>
   <p>Configuration can be loaded from a provided .cfg file and is stored in %HOME%/.slingshot_rv_autoloader.cfg</p>
-  <p>Copyright 2025 Slingshot Systems Inc</p>
-  <a href="https://github.com/Slingshot-Systems/slingshot-rv-autoloader">https://github.com/Slingshot-Systems/slingshot-rv-autoloader</a>
+  <p>For more information, please visit
+  <a href="https://github.com/Slingshot-Systems/slingshot-rv-autoloader">https://github.com/Slingshot-Systems/slingshot-rv-autoloader</a></p>
   <br>
-  <a href="www.slingshotsystems.io">www.slingshotsystems.io</a>
+  <p>Copyright 2025 Slingshot Systems Inc<br>
+  <a href="www.slingshotsystems.io">www.slingshotsystems.io</a></p>

--- a/src/ocio/studio-config-v2.1.0_aces-v1.3_ocio-v2.2.ocio
+++ b/src/ocio/studio-config-v2.1.0_aces-v1.3_ocio-v2.2.ocio
@@ -80,6 +80,15 @@ inactive_colorspaces: [CIE XYZ-D65 - Display-referred, CIE XYZ-D65 - Scene-refer
 
 looks:
   - !<Look>
+    name: slingshot_lut
+    process_space: scene_linear
+    transform: !<FileTransform> {src: "${LUT_PATH}", interpolation: linear}
+  - !<Look>
+    name: slingshot_cdl
+    process_space: scene_linear
+    transform: !<FileTransform> {src: "${CDL_PATH}", cccid: 0}
+
+  - !<Look>
     name: ACES 1.3 Reference Gamut Compression
     process_space: ACES2065-1
     description: |

--- a/src/slingshot_autoloader.py
+++ b/src/slingshot_autoloader.py
@@ -78,7 +78,11 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
         logger.setLevel(logging.DEBUG if self._settings.debug else logging.INFO)
 
         if self._settings.load_luts_enabled:
-            OCIO.SetCurrentConfig(get_ocio_config(self.config))
+            try:
+                OCIO.SetCurrentConfig(get_ocio_config(self.config))
+            except Exception as e:
+                logger.error(f"Failed to load OCIO config: {e}")
+                self._settings.load_luts_enabled = False
 
         init_bindings = [
             (

--- a/src/slingshot_autoloader.py
+++ b/src/slingshot_autoloader.py
@@ -11,8 +11,8 @@ from string import Template
 from typing import TYPE_CHECKING, Callable
 
 import PyOpenColorIO as OCIO
-from rv import commands, extra_commands, rvtypes
 
+from rv import commands, extra_commands, rvtypes
 from rv_menu_schema import MenuItem
 from slingshot_autoloader_config import (
     get_ocio_config,
@@ -423,7 +423,7 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
             {
                 "ocio.function": "color",
                 "ocio.inColorSpace": self.config.color.exr_colorspace,
-                "ocio_color.outColorSpace": self.config.color.working_space,
+                "ocio_color.outColorSpace": "scene_linear",
             },
         )
 
@@ -434,11 +434,28 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
 
         look_pipeline = []
 
+        # this is not the right way to do this, ideally all these transforms would be defined in one look in the ocio.config
+        # However, that means we would have to hardcode the colorspaces (trying to pass them in via context doesn't seem to work)
+        # So to keep them configurable, we're going to do it with a bunch of look nodes
         if self.config.color.look_cdl:
-            look_pipeline.append("RVColor")
+            look_pipeline += [
+                "OCIOLook",  # scene_linear to camera space (log)
+                "OCIOLook",  # CDL
+                "OCIOLook",  # camera space (log) back to scene_linear
+            ]
 
         if self.config.color.look_lut:
-            look_pipeline += ["RVLookLUT", "Rec709ToLinear"]
+            look_pipeline = [
+                "OCIOLook",  # scene_linear to camera space (log)
+                "OCIOLook",  # LUT
+            ]
+
+            # convert output space back to scene_linear if necessary
+            # it would be better to handle this in OCIO as well, but since we're not using for OCIO for .movs yet it's easier to use RV's built in node.
+            if self.config.color.mov_colorspace == "sRGB":
+                look_pipeline.append("sRGBToLinear")
+            elif self.config.color.mov_colorspace == "Rec709":
+                look_pipeline.append("Rec709ToLinear")
 
         commands.setStringProperty(f"{look_pipe}.pipeline.nodes", look_pipeline, True)
 
@@ -447,11 +464,16 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
 
         # print a debug summary
         _look_pipe_nodes = commands.nodesInGroup(look_pipe)
-        _look_pipe_node_summary = [
-            f"{commands.nodeType(node)}: {node}" for node in _look_pipe_nodes
-        ]
-        _look_pipe_summary = ",\n".join(_look_pipe_node_summary)
-        logger.debug(f"{look_pipe}: {_look_pipe_summary}")
+        logger.debug(f"look pipe nodes: {_look_pipe_nodes}")
+        for node in _look_pipe_nodes:  # last node is the colorPipeline node
+            if commands.nodeType(node).startswith("OCIO"):
+                logger.debug(
+                    f" - {commands.nodeType(node)}: {node}\n"
+                    f"    function: {commands.getStringProperty(f'{node}.ocio.function', 0, 1)[0]}\n"
+                    f"    in colorspace: {commands.getStringProperty(f'{node}.ocio.inColorSpace', 0, 1)[0]}\n"
+                    f"    out colorspace: {commands.getStringProperty(f'{node}.ocio_color.outColorSpace', 0, 1)[0]}\n"
+                    f"    look: {commands.getStringProperty(f'{node}.ocio_look.look', 0, 1)[0]}"
+                )
 
     def _add_look_cdl(self, source_path: Path, look_pipe: str):
         if not self.config.color.look_cdl:
@@ -461,9 +483,34 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
             logger.warning("Can't load look CDL")
             return
 
-        color_node = extra_commands.nodesInGroupOfType(look_pipe, "RVColor")[0]
+        cdl_nodes = extra_commands.nodesInGroupOfType(look_pipe, "OCIOLook")
         logger.info(f"Loading look CDL {cdl_path}")
-        commands.readCDL(str(cdl_path), color_node, True)
+        # commands.readCDL(str(cdl_path), color_node, True)
+        applyOCIOProps(
+            cdl_nodes[0],  # lin to log
+            {
+                "ocio.function": "color",
+                "ocio.inColorSpace": "scene_linear",
+                "ocio_color.outColorSpace": self.config.color.working_space,
+            },
+        )
+        applyOCIOProps(
+            cdl_nodes[1],
+            {
+                "ocio.function": "look",
+                "ocio_look.look": "slingshot_cdl",
+                "ocio.inColorSpace": "scene_linear",
+            },
+            context={"CDL_PATH": str(cdl_path)},
+        )
+        applyOCIOProps(
+            cdl_nodes[2],  # log to lin
+            {
+                "ocio.function": "color",
+                "ocio.inColorSpace": self.config.color.working_space,
+                "ocio_color.outColorSpace": "scene_linear",
+            },
+        )
 
     def _add_look_lut(self, source_path: Path, look_pipe: str):
         if not self.config.color.look_lut:
@@ -473,9 +520,27 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
             logger.warning("Can't load look LUT")
             return
 
-        look_node = extra_commands.nodesInGroupOfType(look_pipe, "RVLookLUT")[0]
+        look_nodes = extra_commands.nodesInGroupOfType(look_pipe, "OCIOLook")
+
         logger.info(f"Loading look LUT: {lut_path}")
-        commands.readLUT(str(lut_path), look_node, True)
+        # commands.readLUT(str(lut_path), look_node, True)
+        applyOCIOProps(
+            look_nodes[-2],  # lin to log
+            {
+                "ocio.function": "color",
+                "ocio.inColorSpace": "scene_linear",
+                "ocio_color.outColorSpace": self.config.color.working_space,
+            },
+        )
+        applyOCIOProps(
+            look_nodes[-1],
+            {
+                "ocio.function": "look",
+                "ocio_look.look": "slingshot_lut",
+                "ocio.inColorSpace": "scene_linear",
+            },
+            context={"LUT_PATH": str(lut_path)},
+        )
 
     def after_progressive_loading(self, event: "Event"):
         logger.debug(f"after_progressive_loading: {event.contents()}")
@@ -532,7 +597,9 @@ def createMode():
     return SlingshotAutoLoaderMode()
 
 
-def applyOCIOProps(node: str, properties: "OCIOProperties"):
+def applyOCIOProps(
+    node: str, properties: "OCIOProperties", context: dict | None = None
+):
     for prop, value in properties.items():
         if isinstance(value, str):
             commands.setStringProperty(f"{node}.{prop}", [value], True)
@@ -544,3 +611,11 @@ def applyOCIOProps(node: str, properties: "OCIOProperties"):
             raise ValueError(
                 f"Cannot set property {prop} with value of type {type(value)}"
             )
+
+    if context:
+        for key, value in context.items():
+            if not commands.propertyExists(f"{node}.ocio_context.{key}"):
+                commands.newProperty(
+                    f"{node}.ocio_context.{key}", commands.StringType, 1
+                )
+            commands.setStringProperty(f"{node}.ocio_context.{key}", [value], True)

--- a/src/slingshot_autoloader_config.py
+++ b/src/slingshot_autoloader_config.py
@@ -7,6 +7,7 @@ import shutil
 from configparser import ConfigParser
 from dataclasses import asdict, dataclass, field, is_dataclass
 from pathlib import Path
+from typing import Literal
 
 import PyOpenColorIO as OCIO
 
@@ -33,7 +34,7 @@ class AutoloadPlatesConfig:
 
 @dataclass
 class AutoloadColorConfig:
-    mov_colorspace: str = "Rec709"
+    mov_colorspace: Literal["sRGB", "Rec709", "Linear"] = "Rec709"
     exr_colorspace: str = "ACES2065-1"
     working_space: str = "ACEScc"
     look_cdl: str | None = None
@@ -98,8 +99,12 @@ def _convert_configparser_to_config(config: ConfigParser) -> AutoloaderConfig:
         if config.has_section("other")
         else {},
         color=AutoloadColorConfig(
-            mov_colorspace=config["color"].get("mov_colorspace")
-            or AutoloadColorConfig.__dataclass_fields__["mov_colorspace"].default,
+            mov_colorspace=(
+                value
+                if (value := config["color"].get("mov_colorspace"))
+                in ("sRGB", "Rec709", "Linear")
+                else AutoloadColorConfig.__dataclass_fields__["mov_colorspace"].default
+            ),
             exr_colorspace=config["color"].get("exr_colorspace")
             or AutoloadColorConfig.__dataclass_fields__["exr_colorspace"].default,
             working_space=config["color"].get("working_space")


### PR DESCRIPTION
Previously, we were using OCIO to linearize EXRs and convert them to whatever working camera space was required, but then we still used RV's built in CDL and LUT nodes to apply color on top. This _should_ work okay, but RV is finicky about LUT format, especially when dealing with HDR and over-white values (> 1.0)

OCIO is the standard, so this PR updates the plugin to use OCIO for the EXR color pipeline.

The only downside is you can no longer toggle the LUT/CDL on or off from RV's color menu.  A `todo` is to add our own toggles into the Autoloader menu.

Note that we're still using RV's native color nodes for .mov files, and as the last step in the EXR color pipeline (Rec709ToLinear). This should probably be converted over to ocio someday as well.