### PR TITLE
feat!: Add option to configure LUT output colorspace

### DIFF
--- a/slingshot_rv_autoloader.cfg.EXAMPLE
+++ b/slingshot_rv_autoloader.cfg.EXAMPLE
@@ -71,3 +71,8 @@ working_space = ARRI LogC4
 ; - A path relative to the source media to a LUT, with wildcard support (e.g. ../*.cube)
 ; Note: A Rec709ToLinear node will automatically be added after this LUT
 ;look_lut = ../../../plate/*/*.cube
+
+; The LUT output space that we expect the EXRs to be in once the LUT is applied.
+; This is used to bring the final result back to scene linear.
+; It's usually scene_linear (ACEScc) but in some cases it might be Rec709 (g24_rec709)
+;look_lut_out_colorspace = ACEScc

--- a/src/slingshot_autoloader.py
+++ b/src/slingshot_autoloader.py
@@ -173,6 +173,10 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
                                 label=f"    Look LUT: {self.config.color.look_lut}",
                                 stateHook=lambda: commands.DisabledMenuState,
                             ).tuple(),
+                            MenuItem(
+                                label=f"    Look LUT Output Colorspace: {self.config.color.look_lut_out_colorspace}",
+                                stateHook=lambda: commands.DisabledMenuState,
+                            ).tuple(),
                             MenuItem("_").tuple(),
                             MenuItem(
                                 label="Load config from file...",

--- a/src/slingshot_autoloader.py
+++ b/src/slingshot_autoloader.py
@@ -440,35 +440,49 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
             source_group, "RVLookPipelineGroup"
         )[0]
 
-        look_pipeline = []
-
         # this is not the right way to do this, ideally all these transforms would be defined in one look in the ocio.config
         # However, that means we would have to hardcode the colorspaces (trying to pass them in via context doesn't seem to work)
         # So to keep them configurable, we're going to do it with a bunch of look nodes
+
+        look_pipeline = [
+            "OCIOLook",  # scene_linear to working space (log)
+            "OCIOLook",  # working space to linear (log)
+        ]
+
         if self.config.color.look_cdl:
-            look_pipeline += [
-                "OCIOLook",  # scene_linear to camera space (log)
-                "OCIOLook",  # CDL
-                "OCIOLook",  # camera space (log) back to scene_linear
-            ]
+            look_pipeline.append("OCIOLook")  # CDL
 
         if self.config.color.look_lut:
-            look_pipeline = [
-                "OCIOLook",  # scene_linear to camera space (log)
-                "OCIOLook",  # LUT
-            ]
-
-            # convert output space back to scene_linear if necessary
-            # it would be better to handle this in OCIO as well, but since we're not using for OCIO for .movs yet it's easier to use RV's built in node.
-            if self.config.color.mov_colorspace == "sRGB":
-                look_pipeline.append("sRGBToLinear")
-            elif self.config.color.mov_colorspace == "Rec709":
-                look_pipeline.append("Rec709ToLinear")
+            look_pipeline.append("OCIOLook")  # LUT
 
         commands.setStringProperty(f"{look_pipe}.pipeline.nodes", look_pipeline, True)
+        look_nodes = extra_commands.nodesInGroupOfType(look_pipe, "OCIOLook")
 
-        self._add_look_cdl(source_path, look_pipe)
-        self._add_look_lut(source_path, look_pipe)
+        applyOCIOProps(
+            look_nodes[0],  # lin to working space
+            {
+                "ocio.function": "color",
+                "ocio.inColorSpace": "scene_linear",
+                "ocio_color.outColorSpace": self.config.color.working_space,
+            },
+        )
+
+        applyOCIOProps(
+            look_nodes[-1],  # lut output space to linear
+            {
+                "ocio.function": "color",
+                "ocio.inColorSpace": self.config.color.look_lut_out_colorspace
+                if self.config.color.look_lut
+                else self.config.color.working_space,
+                "ocio_color.outColorSpace": "scene_linear",
+            },
+        )
+
+        if self.config.color.look_cdl:
+            self._add_look_cdl(source_path, look_nodes[1])
+
+        if self.config.color.look_lut:
+            self._add_look_lut(source_path, look_nodes[-2])
 
         # print a debug summary
         _look_pipe_nodes = commands.nodesInGroup(look_pipe)
@@ -483,7 +497,7 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
                     f"    look: {commands.getStringProperty(f'{node}.ocio_look.look', 0, 1)[0]}"
                 )
 
-    def _add_look_cdl(self, source_path: Path, look_pipe: str):
+    def _add_look_cdl(self, source_path: Path, node: str):
         if not self.config.color.look_cdl:
             return
 
@@ -491,19 +505,10 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
             logger.warning("Can't load look CDL")
             return
 
-        cdl_nodes = extra_commands.nodesInGroupOfType(look_pipe, "OCIOLook")
         logger.info(f"Loading look CDL {cdl_path}")
         # commands.readCDL(str(cdl_path), color_node, True)
         applyOCIOProps(
-            cdl_nodes[0],  # lin to log
-            {
-                "ocio.function": "color",
-                "ocio.inColorSpace": "scene_linear",
-                "ocio_color.outColorSpace": self.config.color.working_space,
-            },
-        )
-        applyOCIOProps(
-            cdl_nodes[1],
+            node,
             {
                 "ocio.function": "look",
                 "ocio_look.look": "slingshot_cdl",
@@ -511,16 +516,8 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
             },
             context={"CDL_PATH": str(cdl_path)},
         )
-        applyOCIOProps(
-            cdl_nodes[2],  # log to lin
-            {
-                "ocio.function": "color",
-                "ocio.inColorSpace": self.config.color.working_space,
-                "ocio_color.outColorSpace": "scene_linear",
-            },
-        )
 
-    def _add_look_lut(self, source_path: Path, look_pipe: str):
+    def _add_look_lut(self, source_path: Path, node: str):
         if not self.config.color.look_lut:
             return
 
@@ -528,20 +525,11 @@ class SlingshotAutoLoaderMode(rvtypes.MinorMode):
             logger.warning("Can't load look LUT")
             return
 
-        look_nodes = extra_commands.nodesInGroupOfType(look_pipe, "OCIOLook")
-
         logger.info(f"Loading look LUT: {lut_path}")
         # commands.readLUT(str(lut_path), look_node, True)
+
         applyOCIOProps(
-            look_nodes[-2],  # lin to log
-            {
-                "ocio.function": "color",
-                "ocio.inColorSpace": "scene_linear",
-                "ocio_color.outColorSpace": self.config.color.working_space,
-            },
-        )
-        applyOCIOProps(
-            look_nodes[-1],
+            node,
             {
                 "ocio.function": "look",
                 "ocio_look.look": "slingshot_lut",

--- a/src/slingshot_autoloader_config.py
+++ b/src/slingshot_autoloader_config.py
@@ -39,6 +39,7 @@ class AutoloadColorConfig:
     working_space: str = "ACEScc"
     look_cdl: str | None = None
     look_lut: str | None = None
+    look_lut_out_colorspace: str = "g24_rec709"
 
 
 @dataclass(frozen=True)
@@ -111,6 +112,10 @@ def _convert_configparser_to_config(config: ConfigParser) -> AutoloaderConfig:
             or AutoloadColorConfig.__dataclass_fields__["working_space"].default,
             look_cdl=config["color"].get("look_cdl"),
             look_lut=config["color"].get("look_lut"),
+            look_lut_out_colorspace=config["color"].get("look_lut_out_colorspace")
+            or AutoloadColorConfig.__dataclass_fields__[
+                "look_lut_out_colorspace"
+            ].default,
         )
         if config.has_section("color")
         else AutoloadColorConfig(),
@@ -173,7 +178,7 @@ def get_ocio_config(autoloader_config: AutoloaderConfig) -> OCIO.Config:
     config = config_module.CreateFromFile(str(ocio_config_path))
 
     # validate configuration
-    for _field in ["working_space", "exr_colorspace"]:
+    for _field in ["working_space", "exr_colorspace", "look_lut_out_colorspace"]:
         colorspace = getattr(autoloader_config.color, _field)
         if not (validated_colorspace := config.parseColorSpaceFromString(colorspace)):
             raise Exception(


### PR DESCRIPTION
### Summary

- Added option to configure LUT output colorspace (`look_lut_out_colorspace` config property)
- Use OCIO to convert LUT output back to scene_linear (breaking change)